### PR TITLE
Set WORKDIR in generated Dockerfile prior to running application.

### DIFF
--- a/src/build-image/DotnetDockerfileBuilder.cs
+++ b/src/build-image/DotnetDockerfileBuilder.cs
@@ -36,6 +36,7 @@ class DotnetDockerfileBuilder
         sb.AppendLine($"FROM {fromImage}");
         sb.AppendLine($"COPY --from=build-env /out /app");
         sb.AppendLine("ENV ASPNETCORE_URLS=http://*:8080");
+        sb.AppendLine("WORKDIR /app");
         sb.AppendLine($"CMD [\"dotnet\", \"/app/{assemblyName}\"]");
         return sb.ToString();
     }


### PR DESCRIPTION
The Dockerfile generated copies the application to /app prior to execution. However, the WORKDIR value is never set to /app. For ASP.NET projects, this causes Kestrel to return 404 for dependencies in wwwroot such as .js and .css files.