### PR TITLE
Tag as 'latest' by default.

### DIFF
--- a/src/build-image/BuildCommand.cs
+++ b/src/build-image/BuildCommand.cs
@@ -154,7 +154,7 @@ class BuildCommand : RootCommand
             }
             else
             {
-                string t = projectInformation.ContainerImageTag ?? projectInformation.Version ?? "latest";
+                string t = projectInformation.ContainerImageTag ?? "latest";
                 tags.Add($"{name}:{t}");
             }
         }

--- a/src/build-image/ProjectReader.cs
+++ b/src/build-image/ProjectReader.cs
@@ -5,8 +5,6 @@ class ProjectInformation
     public string? DotnetVersion { get; set; }
     public string? AssemblyName { get; set; }
 
-    public string? Version { get; set; }
-
     // Match properties of built-in sdk support
     // See https://github.com/dotnet/sdk-container-builds/blob/main/docs/ContainerCustomization.md.
     public string? ContainerImageTag { get; set; }
@@ -54,7 +52,6 @@ class ProjectReader
             ContainerRegistry = GetProperty(project, "ContainerRegistry"),
             ContainerBaseImage = GetProperty(project, "ContainerBaseImage"),
             ContainerWorkingDirectory = GetProperty(project, "ContainerWorkingDirectory"),
-            Version = GetProperty(project, "Version"),
 
             ContainerImageArchitecture = GetProperty(project, "ContainerImageArchitecture"),
             ContainerSdkImage = GetProperty(project, "ContainerSdkImage"),


### PR DESCRIPTION
Follow the SDK container tooling and use 'latest'
instead of the .NET project Version as the default tag.